### PR TITLE
Support Newer Versions of the redis Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     diff-lcs (1.2.5)
     minitest (5.11.3)
     rake (10.3.2)
-    redis (4.0.2)
+    redis (3.3.5)
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,15 @@ PATH
   remote: .
   specs:
     cb2 (0.0.3)
-      redis (~> 3.1)
+      redis (>= 3.1, < 5)
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    minitest (5.11.3)
     rake (10.3.2)
-    redis (3.2.0)
+    redis (4.0.2)
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -30,7 +31,11 @@ PLATFORMS
 
 DEPENDENCIES
   cb2!
+  minitest
   rake (> 0)
   rr (~> 1.1)
   rspec (~> 3.1)
   timecop (~> 0.7)
+
+BUNDLED WITH
+   1.16.6

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,9 +10,10 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 3.1"
+  s.add_dependency "redis", ">= 3.1", "< 5"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"
   s.add_development_dependency "timecop", "~> 0.7"
+  s.add_development_dependency "minitest"
 end

--- a/lib/cb2/strategies/rolling_window.rb
+++ b/lib/cb2/strategies/rolling_window.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class CB2::RollingWindow
   attr_accessor :service, :duration, :threshold, :reenable_after, :redis
 

--- a/spec/strategies/rolling_window_spec.rb
+++ b/spec/strategies/rolling_window_spec.rb
@@ -51,7 +51,7 @@ describe CB2::RollingWindow do
     it "resets the counter so half open breakers go back to closed" do
       redis.set(strategy.key, Time.now.to_i - 601)
       strategy.success
-      assert_equal nil, redis.get(strategy.key)
+      assert_nil redis.get(strategy.key)
     end
   end
 


### PR DESCRIPTION
### What This Fixes ###
Newer versions of the redis gem include bug fixes, and will likely include clustering support in the near future. (4.1.0.beta1 includes this support.) The cb2 gem uses get, set, del, zremrangebyscore, zadd, zcard and flushdb methods. As these methods have not changed in newer versions of the redis gem, the only change necessary is to update the cb2 gemspec.

This change also adds a require for 'securerandom' to rolling_window.rb. Without it, the reference to SecureRandom is undefined, at least on Ruby 2.3.7.

Finally, added a development dependency for minitest to the gemspec. It appears that this library was included in older versions of Ruby, but is now provided as a separate gem.

### Testing ###
* Ran unit tests.
* We are using this in production (recent version of redis-rb master with cb2).